### PR TITLE
Add support for codeception 4 + DrupalFinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,12 @@ If codeception was not previously set up:
 Provides full bootstrapping in to Drupal before test. Allows using drupal API in test cases.
 
 ### Configuration
-- root: Drupal root. Defaults to codeception root + `/web`.
 - server: Server and execution environment information.
+- root: Drupal root. Uses DrupalFinder to detect the Drupal root. Falls back to codeception root + `/web`. (optional)
 
 ```
 modules:
     - DrupalBootstrap:
-        root: './web'
         server:
             SERVER_PORT: null
             REQUEST_URI: '/'
@@ -229,7 +228,7 @@ Includes:
     - FormField: Fields that can be set to cardinality unlimited
     - MTOFormField: Single value fields.
     - ParagraphFormField: Paragraph form fields.
-    
+
 ### Usage
 
 Create paragraph field with machine name field_page_elements.

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,10 @@
         }
     ],
     "require": {
-        "codeception/codeception": "^2.3 || ^3.0",
-        "fzaninotto/faker": "^1.8"
+        "codeception/codeception": "^4.0",
+        "fzaninotto/faker": "^1.8",
+        "codeception/module-webdriver": "^1.1",
+        "webflo/drupal-finder": "^1.2"
     },
     "require-dev": {
         "composer/installers": "^1",

--- a/src/Codeception/Module/DrupalBootstrap.php
+++ b/src/Codeception/Module/DrupalBootstrap.php
@@ -8,6 +8,8 @@ use Codeception\Module;
 use Codeception\TestDrupalKernel;
 use Symfony\Component\HttpFoundation\Request;
 use Drupal\Core\DrupalKernel;
+use DrupalFinder\DrupalFinder;
+
 
 /**
  * Class DrupalBootstrap.
@@ -46,7 +48,19 @@ class DrupalBootstrap extends Module {
   public function __construct(ModuleContainer $container, $config = NULL) {
     parent::__construct($container, $config);
     if (!isset($this->config['root'])) {
-      $this->_setConfig(['root' => Configuration::projectDir() . 'web']);
+
+      $drupalFinder = new DrupalFinder();
+
+      $drupalFinder->locateRoot(getcwd());
+      $drupalRoot = $drupalFinder->getDrupalRoot();
+
+      // Autodetect Drupal root.
+      if ($drupalRoot) {
+        $this->_setConfig(['root' => $drupalRoot]);
+      }
+      else {
+        $this->_setConfig(['root' => Configuration::projectDir() . 'web']);
+      }
     }
     chdir($this->_getConfig('root'));
     $request = Request::createFromGlobals();


### PR DESCRIPTION
This adds codeception 4 support. Nothing in the code really needed to change other than the extra composer dependencies required for webdriver to work. I didn't notice anything else breaking but I certainly didn't test every option. But login, create entity, and similar actions still work.

Not sure how you want to handle the new deps since codeception/module-webdriver likely won't install on earlier versions. If you want to create a new major branch release or what.

This also includes a change to automatically discover Drupal's webroot using DrupalFinder. I can split this out if you want but that's really the only code change.