### PR TITLE
Do not fail tests when user entity cleanup fails

### DIFF
--- a/src/Codeception/Module/DrupalUser.php
+++ b/src/Codeception/Module/DrupalUser.php
@@ -174,7 +174,11 @@ class DrupalUser extends Module {
       /** @var \Drupal\user\Entity\User $user */
       foreach ($users as $user) {
         $this->deleteUsersContent($user->id());
-        $user->delete();
+        try {
+          $user->delete();
+        } catch (\Exception $e) {
+          continue;
+        }
       }
     }
   }


### PR DESCRIPTION
There are cases when the user delete method during cleanup will throw an unrelated exceptions. This prevents such random exceptions from failing the entire test.