### PR TITLE
Make the title parameter optional for link fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ $i->fillTextField(FormField::field_title($page_elements), 'Mans nosukums');
 
 // Fill link field.
 $i->fillLinkField(FormField::field_link($page_elements), 'http://example.com', 'Example');
+$i->fillLinkField(FormField::field_link($page_elements), 'http://example.com');
 
 // Add taxonomy term reference for tags field.
 $field_tags = FormField::field_tags();

--- a/src/Codeception/Module/DrupalAcceptance.php
+++ b/src/Codeception/Module/DrupalAcceptance.php
@@ -91,9 +91,11 @@ class DrupalAcceptance extends Module {
    * @param string $title
    *   Title.
    */
-  public function fillLinkField(IdentifiableFormFieldInterface $field, $uri, $title) {
+  public function fillLinkField(IdentifiableFormFieldInterface $field, $uri, $title = NULL) {
     $this->webdriver->fillField($field->uri, $uri);
-    $this->webdriver->fillField($field->title, $title);
+    if (isset($title)) {
+      $this->webdriver->fillField($field->title, $title);
+    }
   }
 
   /**


### PR DESCRIPTION
Links fields can be configured to not show the title field at all, therefore the title parameter should be optional.