### PR TITLE
Drush timeout option and return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ Provides drush (`runDrush`) command.
 
 ### Configuration
 - working_directory: Working directory where drush should be executed. Defaults to codeception root.
+- timeout: Timeout in seconds for drush command. Set to 0 for no timeout. Default to 60 seconds.
 - drush: Drush executable. Defaults to `drush`.
 ```
 modules:
     - DrupalDrush:
         working_directory: './web'
+        timeout: 120
         drush: './vendor/bin/drush'
           options:
             uri: http://mydomain.com
@@ -60,9 +62,17 @@ modules:
 
 ### Usage
 
-Run drush config import and store output.
+Run drush status and store output.
 
-`$output = $i->runDrush('cim -y');`
+`$output = $i->runDrush('status');`
+
+Run drush config import and store output from STDERR.
+
+`$output = $i->runDrush('cim -y', [], TRUE)->getErrorOutput();`
+
+Run drush cache rebuild and store the exit code.
+
+`$exit_code = $i->runDrush('cr', [], TRUE)->getExitCode();`
 
 Get one-time login url.
 

--- a/src/Codeception/Module/DrupalDrush.php
+++ b/src/Codeception/Module/DrupalDrush.php
@@ -13,6 +13,7 @@ use Codeception\Util\Drush;
  *     modules:
  *        - DrupalDrush:
  *          working_directory: './web'
+ *          timeout: 120
  *          drush: './vendor/bin/drush'
  *          alias: '@mysite.com'
  *          options:
@@ -42,11 +43,14 @@ class DrupalDrush extends Module {
    *   e.g. "en devel -y".
    * @param array $options
    *   Associative array of options.
+   * @param bool $return_process
+   *   If TRUE, the Process object will be returned. If false, the output of
+   *   Process::getOutput() will be returned. Defaults to FALSE.
    *
-   * @return string
-   *   The process output.
+   * @return string|\Symfony\Component\Process\Process
+   *   The process output, or the process itself.
    */
-  public function runDrush($command, array $options = []) {
+  public function runDrush($command, array $options = [], $return_process = FALSE) {
     if ($alias = $this->_getConfig('alias')) {
       $command = $alias . ' ' . $command;
     }
@@ -56,7 +60,7 @@ class DrupalDrush extends Module {
     elseif ($this->_getConfig('options')) {
       $command = $this->normalizeOptions($this->_getConfig('options')) . $command;
     }
-    return Drush::runDrush($command, $this->_getConfig('drush'), $this->_getConfig('working_directory'));
+    return Drush::runDrush($command, $this->_getConfig('drush'), $this->_getConfig('working_directory'), $this->_getConfig('timeout'), $return_process);
   }
 
   /**

--- a/src/Codeception/Module/DrupalUser.php
+++ b/src/Codeception/Module/DrupalUser.php
@@ -142,7 +142,7 @@ class DrupalUser extends Module {
    */
   public function logInAs($username) {
     $alias = $this->_getConfig('alias') ? $this->_getConfig('alias') . ' ' : '';
-    $output = Drush::runDrush($alias. 'uli --name=' . $username, $this->_getConfig('drush'), $this->_getConfig('working_directory'));
+    $output = Drush::runDrush($alias. 'uli --name=' . $username, $this->_getConfig('drush'), $this->_getConfig('working_directory'), $this->_getConfig('timeout'));
     $gen_url = str_replace(PHP_EOL, '', $output);
     $url = substr($gen_url, strpos($gen_url, '/user/reset'));
     $this->driver->amOnPage($url);

--- a/src/Codeception/Util/Drush.php
+++ b/src/Codeception/Util/Drush.php
@@ -21,11 +21,16 @@ class Drush {
    *   The drush command to use.
    * @param string $pwd
    *   Working directory.
+   * @param int|float $timeout.
+   *   Drush execution timeout.
+   * @param bool $return_process
+   *   If TRUE, the Process object will be returned. If false, the output of
+   *   Process::getOutput() will be returned. Defaults to FALSE.
    *
-   * @return string
-   *   The process output.
+   * @return string|\Symfony\Component\Process\Process
+   *   The process output, or the process object itself.
    */
-  public static function runDrush($command, $drush = 'drush', $pwd = NULL) {
+  public static function runDrush($command, $drush = 'drush', $pwd = NULL, $timeout = NULL, $return_process = FALSE) {
     $command_args = array_merge([$drush], explode(' ', $command));
     $process = new Process($command_args);
 
@@ -34,7 +39,14 @@ class Drush {
       $process->setWorkingDirectory($pwd);
     }
 
-    return $process->mustRun()->getOutput();
+    // Set timeout if configured.
+    if (isset($timeout)) {
+      $process->setTimeout($timeout);
+    }
+
+    $process->mustRun();
+
+    return $return_process ? $process : $process->getOutput();
   }
 
 }


### PR DESCRIPTION
Proposed changes:
- add timeout option to enable running time-consuming commands
- introduce new parameter $return_process, to allow caller to choose which return value runDrush() returns: the normal string output, or the whole Process object. This is needed since some drush commands put their output to STDERR instead of STDOUT. See examples of usage in updated README. The new variable is optional, and default to FALSE, to maintain backwards compability.