### PR TITLE
Issue #21 : Replace fzaninotto/faker with phpfaker/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "codeception/codeception": "^4.0",
-        "fzaninotto/faker": "^1.8",
+        "fakerphp/faker": "^1.23",
         "codeception/module-webdriver": "^1.1",
         "webflo/drupal-finder": "^1.2"
     },


### PR DESCRIPTION
This library is using the Faker library for the Drupal user generation. See `Codeception\Module\DrupalUser`

See:
#21 

I've tested this and the behaviour should be the same. The Drupal user is still created successfully. 

The fakerphp/faker library should still work with php ^7.4.