### PR TITLE
Add support for CKEditor5 in DrupalAcceptance->fillWysiwygEditor

### DIFF
--- a/src/Codeception/Module/DrupalAcceptance.php
+++ b/src/Codeception/Module/DrupalAcceptance.php
@@ -176,6 +176,12 @@ class DrupalAcceptance extends Module {
   public function fillWysiwygEditor(IdentifiableFormFieldInterface $field, $content) {
     $selector = $this->webdriver->grabAttributeFrom($field->value, 'id');
     $script = "jQuery(function(){CKEDITOR.instances[\"$selector\"].setData(\"$content\")});";
+    // Check if CKEditor5 is in use. If so, override the script as global
+    // registry of editor instances is no longer available and a different
+    // approach is used to access them via DOM.
+    if (!empty($this->webdriver->grabAttributeFrom($field->value, 'data-ckeditor5-id'))) {
+      $script = "document.querySelector(\"#$selector\").nextSibling.querySelector(\".ck-editor__editable_inline\").ckeditorInstance.setData(\"$content\")";
+    }
     $this->webdriver->executeInSelenium(function (RemoteWebDriver $webDriver) use ($script) {
       $webDriver->executeScript($script);
     });


### PR DESCRIPTION
Motivation:
- `CKEditor5` has no global registry of editor instances and the current script used for setting WYSIWYG field's value no longer works if CKEditor5 is utilised. This leads to failing tests (i.e., when comparing the actual value with the expected one after filling out a WYSIWYG field)

Proposed change:
- Enable filling CKEditor5 based fields while keeping backwards compatibility with CKEditor4 (and below) if needed.
- The proposed solution checks if there is `data-ckeditor5-id` attribute present for the WYSIWYG field. If so, original script is overridden with CKEditor5 compatible version (see https://ckeditor.com/docs/ckeditor5/latest/examples/how-tos.html#how-to-get-the-editor-instance-object-from-the-dom-element). Therefore, we don't need any additional parameters of functions to handle CKEditor5 specifically as the existing one can decide itself which version of CKEditor is in use for the particular field and act accordingly.